### PR TITLE
Directive is not working with input type="number"

### DIFF
--- a/dist/floating-label.css
+++ b/dist/floating-label.css
@@ -8,14 +8,12 @@
   left: 10px;
   font-size: 11px;
   -webkit-transform: translateY(20px);
-      -ms-transform: translateY(20px);
           transform: translateY(20px);
   transition: -webkit-transform 0.15s ease-in;
   transition: transform 0.15s ease-in;
 }
 .floating-label label.active {
   -webkit-transform: translateY(0px);
-      -ms-transform: translateY(0px);
           transform: translateY(0px);
 }
 .floating-label input {

--- a/dist/floating-label.js
+++ b/dist/floating-label.js
@@ -77,7 +77,7 @@
 
         $scope.$watch(ngModelKey, function (newValue) {
             // if the field is not empty, show the label, otherwise hide it
-            $scope.showLabel = newValue && newValue.length > 0;
+            $scope.showLabel = newValue && newValue.toString().length > 0;
         });
     }
 

--- a/src/floating-label.directive.js
+++ b/src/floating-label.directive.js
@@ -77,7 +77,7 @@
 
         $scope.$watch(ngModelKey, function (newValue) {
             // if the field is not empty, show the label, otherwise hide it
-            $scope.showLabel = typeof newValue === 'string' && newValue.length > 0;
+            $scope.showLabel = newValue && newValue.toString().length > 0;
         });
     }
 


### PR DESCRIPTION
It seems like when the directive is used on an `input` field with `type="number"`, `newValue.length` is undefined as it is not a string. This fix converts the value to string and makes it work properly with numbers.
